### PR TITLE
Fix memory deallocation bug(s)

### DIFF
--- a/svm/bridge.go
+++ b/svm/bridge.go
@@ -231,8 +231,8 @@ func cSvmAppReceiptState(receipt []byte) ([]byte, error) {
 	cErr := cSvmByteArray{}
 
 	defer func() {
-		cReceipt.SvmFree()
-		cInitialState.Free()
+		cInitialState.SvmFree()
+		cReceipt.Free()
 		cErr.SvmFree()
 	}()
 
@@ -253,8 +253,8 @@ func cSvmAppReceiptAddr(receipt []byte) (Address, error) {
 	cErr := cSvmByteArray{}
 
 	defer func() {
-		cReceipt.SvmFree()
-		cAppAddr.Free()
+		cAppAddr.SvmFree()
+		cReceipt.Free()
 		cErr.SvmFree()
 	}()
 
@@ -366,8 +366,8 @@ func cSvmValidateTx(runtime Runtime, appTx []byte) (Address, error) {
 	cErr := cSvmByteArray{}
 
 	defer func() {
-		cAppTx.SvmFree()
-		cAppAddr.Free()
+		cAppAddr.SvmFree()
+		cAppTx.Free()
 		cErr.SvmFree()
 	}()
 
@@ -446,8 +446,8 @@ func cSvmExecReceiptReturns(receipt []byte) (Values, error) {
 	cErr := cSvmByteArray{}
 
 	defer func() {
-		cReceipt.SvmFree()
-		cReturns.Free()
+		cReturns.SvmFree()
+		cReceipt.Free()
 		cErr.SvmFree()
 	}()
 


### PR DESCRIPTION
Fixing memory deallocation bug(s) where `free` was called on the wrong allocator - cgo's instead of rusts's, and vise versa. This caused a problem solely on Windows - process was crashing without any error message.
